### PR TITLE
Added Google Chat feature

### DIFF
--- a/actions/SendGoogleChat/config-default.yml
+++ b/actions/SendGoogleChat/config-default.yml
@@ -1,0 +1,2 @@
+## Placeholder/Temp Google Chat Webhook URL
+webhookURL: "https://chat.googleapis.com/v1/spaces/{API_TOKEN}/messages?key={API_KEY}"

--- a/actions/SendGoogleChat/documentation.md
+++ b/actions/SendGoogleChat/documentation.md
@@ -1,0 +1,159 @@
+#  Google Chat actions
+
+
+This action aims to create an easy way to [format](https://developers.google.com/chat/reference/message-formats) and send alerts as Google Chat messages.
+
+## Quick Links
+[Initial setup](#initial-setup)
+
+[Usage](#usage)
+
+[Examples](#usage-examples)
+
+[Templating](#templating)
+
+<p>&nbsp;</p>
+
+## Initial setup
+
+  
+
+1. Google Chat's webhook functionality is currently only accessible with an [admin account](https://workspace.google.com/products/admin/). 
+
+2. To enable webhooks in your Google Chat room, click on the room's title when it's opened and active on your page. Select **configure webhooks** within the dropdown menu. More information on Google Chat webhook configuration can be found [here](https://developers.google.com/chat/how-tos/webhooks). 
+
+3. Inside the actions folder are specified folders for each service. SendGoogleChat will have a ```config-default.yml``` that holds the value representing your webhook url. Replace this value with your Google Chat Webhook URL you configured in the previous step.  
+
+3. (optional) [Configure](#usage) and [locally test](../../README.md#testing-your-configuration) your Google Chat integration. Once you are satisfied with your configuration, you must [re-deploy](../../README.md#deploy) **Responder** to finalize your changes.
+
+4. Congratulations you should now be able receive custom **Responder** alerts in your Google Chat room!
+	
+  <p>&nbsp;</p>
+
+
+## Usage
+
+The Google Chat integration can be used in a two different ways. 
+
+1. Simple text alerts can be customized to higher complexity using Google's [message formatting guidelines](https://developers.google.com/chat/reference/message-formats). These alteration will be synonymous to your `actions.yml` file located in main directory of this repository. Any changes made within this file will subsequently change the structure of your webhook alert. 
+
+2. Additionally you can utilize templates. By default **Responder** comes with a prebuilt template for AWS. However, in the future we hope to add templates for other platforms. 
+
+<p>&nbsp;</p>
+
+## Usage Examples
+<p>&nbsp;</p>
+
+### Simple message example:
+
+A simple text message can be specified by configuring a value for the `message` property in the `actions.yml` file.
+
+```yml
+
+- rule: TheRuleName
+
+  sequential:
+
+...
+
+- command: SendGoogleChat
+
+  message: "Write your custom message here"
+
+...
+
+```
+
+  
+
+### Simple header example:
+
+A simple header message can be created by adding a value to the `header` property in the `actions.yml` file.
+
+```yml
+
+- rule: TheRuleName
+
+  sequential:
+
+...
+
+- command: SendGoogleChat
+
+  message:
+
+  header: "Write your custom header here"
+
+...
+
+```
+
+  
+
+### Header and values example:
+
+A Header and Values message can be created by adding a value to the `header` property, as well as adding / configuring the `values` property in the `actions.yml` file. 
+
+Values are a JSONPath of the [context object]()
+
+```yml
+
+- rule: TheRuleName
+
+sequential:
+
+...
+
+- command: SendGoogleChat
+
+  message:
+
+  header: "e.g. Root has logged in"
+
+  values:
+
+- label: "e.g. Account"
+
+  value: "$.event.rawEvent.account"
+
+- label: "e.g. From"
+
+  value: "$.event.rawEvent.detail.sourceIPAddress"
+
+...
+
+```
+
+  
+<p>&nbsp;</p>
+
+### Templates example:
+
+It's easy to specify a template as well. This will provide more advanced formatting options. This is also done in the `actions.yml` file. 
+
+As mentioned above, **Responder** comes with a prebuilt template for AWS. 
+The `aws-event` template is preconfigured to be used "right out of the box" with no further setup. But remember the template is just a starting point so feel free to customize it to suit your needs!
+
+For more information on customizing event templates, refer to our  [templating section](#templating) 
+
+```yml
+
+- rule: TheRuleName
+
+  sequential:
+
+...
+
+- command: SendGoogleChat
+
+  template: aws-event
+
+...
+
+```
+
+<p>&nbsp;</p>
+
+## Templating
+
+Existing templates are located in the `actions/SendGoogleChat/templates` directory. The name of the template is the file itself. The existing templates were built referencing this: [Google Chat webhooks formatting](https://developers.google.com/chat/reference/message-formats) 

--- a/actions/SendGoogleChat/index.js
+++ b/actions/SendGoogleChat/index.js
@@ -1,0 +1,130 @@
+const Promise = require("bluebird");
+const { JSONPath } = require("jsonpath-plus");
+const yaml = require("js-yaml");
+const fs = require("fs");
+const path = require("path");
+const Handlebars = require("handlebars");
+const Configuration = require(`${process.cwd()}/models/configuration.js`);
+const config = new Configuration([__dirname]).values;
+const fetch = require("node-fetch");
+const console = require("console");
+
+module.exports = async (action, flow) => {
+    // user webhookURL
+    let webhookURL = config.webhookURL;
+    if (action.webhookURL) {
+        webhookURL = action.webhookURL;
+    };
+
+    return Promise.mapSeries(flow.findings, async (finding) => {
+        // build messages & invoke specified actions
+        const message = buildMessage(finding, action, flow);
+        try {
+            await fetch(webhookURL, {
+                method: "POST",
+                headers: {
+                    Accept: "application/json",
+                    "Content-Type": "application/json"
+                },
+
+                body: JSON.stringify(message)
+            }).then((response) => {
+                // * debug log
+                // console.log(response)
+            });
+
+            return true;
+        } catch (error) {
+            console.error(error);
+            console.log("Sending Google Chat message failed");
+            return false;
+        }
+    });
+};
+
+const buildMessage = (finding, action, flow) => {
+    // checking for template...
+    if (action.template && fs.existsSync(`${__dirname}/templates/${action.template}.yml`)) {
+        const template = Handlebars.compile(fs.readFileSync(`${__dirname}/templates/${action.template}.yml`, "utf8"));
+        // loading template
+        const result = yaml.load(
+            template(
+                {
+                    finding,
+                    action,
+                    flow
+                },
+                {
+                    // security
+                    // not recommended, but can't find a better way for now
+                    allowProtoPropertiesByDefault: true
+                }
+            )
+        );
+        // * message parsing debug
+        // console.log("parsed-result", result);
+        return result;
+    }
+
+    // google chat card msg. format/schema
+    // ref: https://developers.google.com/chat/reference/message-formats
+    const message = {
+        cards: [
+            {
+                sections: [
+                    {
+                        widgets: [
+                            {
+                                textParagraph: {
+                                    text: ""
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
+
+    // schema traversal + message build
+
+    // array markers for pushing sequentially.
+    const cardsLength = message.cards.length - 1;
+    const widgetsLength = message.cards[cardsLength].sections.length - 1;
+
+    if (typeof action.message === "string" || action.message.header) {
+        message.cards[cardsLength].sections[widgetsLength].widgets.push({
+            textParagraph: { text: `<b>${action.message.header || action.message}</b>` }
+        });
+    } else {
+        message.cards[cardsLength].sections[widgetsLength].widgets.push({
+            textParagraph: { text: `<b>${finding.ruleTitle}</b>` }
+        });
+        message.cards[cardsLength].sections[widgetsLength].widgets.pushh({
+            textParagraph: { text: `<b>${finding.message}</b>` }
+        });
+    };
+
+    const sections = [];
+    if (action.message.values) {
+        action.message.values.map((value) => {
+            const result = JSONPath({
+                path: value.value,
+                json: flow
+            });
+            return sections.push({
+                widgets: [
+                    {
+                        textParagraph: { text: `<b>${value.label}</b>` }
+                    },
+                    {
+                        textParagraph: { text: `${result}` }
+                    }]
+            });
+        });
+        message.cards[cardsLength].sections = sections;
+    }
+    // * message build debug
+    // console.log(message)
+    return message;
+};

--- a/actions/SendGoogleChat/templates/aws-event.yml
+++ b/actions/SendGoogleChat/templates/aws-event.yml
@@ -1,0 +1,35 @@
+cards:
+- header:
+    title: Responder Bot
+    imageUrl: https://i.ibb.co/LSd4Fhf/TEXT-RED.png
+  sections:
+  - widgets:
+    - textParagraph:
+        text: "<b>{{finding.ruleTitle}}<b/>"
+    - textParagraph:
+        text: "{{finding.message}}"
+  - widgets:
+    - keyValue:
+        topLabel: Severity
+        content: "{{finding.prettySeverity}}"
+    - keyValue:
+        topLabel: Account
+        content: "{{flow.event.account}}"
+  - widgets:
+    - keyValue:
+        topLabel: Region
+        content: "{{flow.event.region}}"
+    - keyValue:
+        topLabel: IP address
+        content: "{{flow.event.initiatingIP}}"
+  - widgets:
+    - keyValue:
+        topLabel: Initiating user
+        content: "{{flow.event.initiator}}"
+    - keyValue:
+        topLabel: Resources
+        content: "{{#if finding.resources}}
+          {{#each finding.resources}}
+            {{this}}
+          {{/each}}
+        {{/if}}"


### PR DESCRIPTION
## Added Google Chat functionality
[Create Google Chat Ticket](https://github.com/skycrafters/responder/issues/8)

This feature allows webhook management and formatting for the Google Chat API. It's functionality is built on node-fetch. It does not use any platform specific libraries.

**Files added:**

- A ```SendGoogleChat``` folder has been added to the actions folder.
- A template folder has been added with a base template ```aws-event.yml``` 
- ```aws-event.yml``` will contain information about AWS events.
- The ```config-default.yml``` file has been added for users to input their specified API token and secret. 
- The ```documentation.md``` file has been added for reference and resources.
- The ```index.js``` file houses all of the logic for sending messages to the webhook.
<br/>

**Testing:**

_Note:_ Follow the instructions in the ```documentation.md``` for the Google Chat webhook setup.

You can test this feature locally by running one of the three functions in the ```index.js``` file in the main directory

```
node index.js
```

_Note:_ The remediation part of the tests will fail if you are running the tests locally. In order to fully test this feature, make sure to re-deploy your configuration and then do something in your AWS account that will trigger/break one of the rules ```action.js```.

For example:

```
aws iam create-user --user-name noncompliantuser
```
The feature is working correctly if the notifications arriving in your Google Chatroom channel match up with the SendGoogleChat commands in the ```actions.yml``` file located in the main directory.